### PR TITLE
Fix nav & overflow issues | Re-add title on mobile

### DIFF
--- a/index.html
+++ b/index.html
@@ -34,8 +34,10 @@
 
     <!-- Slide content -->
     <div class="slider slide1">
-      <div class="slide-page">
-        <h2 class="slide-title">HOME</h2>
+      <div class="slide-page home-fix">
+        <div class="title-wrapper">
+          <h2 class="slide-title">HOME</h2>
+        </div>
         <div class="home-flex-wrapper">
           <div class="home-flex-img-wrapper">
             <img class="home-flex-img" src="img/picofme1.jpg" alt="Henri">
@@ -51,14 +53,16 @@
             <br><br>
             And looks like he got fed up again and had his friend Chase go through his website and fix it up so he no longer has to worry about it.
             <br><br>
-            Here's that friend's <a href="https://chase-wheeler.netlify.app/">website</a>
+            Here's that friend's <a class="web-link" href="https://chase-wheeler.netlify.app/">website</a>
           </p>
         </div>
       </div>
     </div>
     <div class="slider slide2">
       <div class="slide-page">
-        <h2 class="slide-title" style="margin-top: 75px !important;">Projects</h2>
+        <div class="title-wrapper">
+          <h2 class="slide-title">PROJECTS</h2>
+        </div>
         <div class="projects-flex-wrapper">
           <div class="projects-flex-item">
             <div class="project-title">
@@ -154,8 +158,9 @@
     </div>
     <div class="slider slide3">
       <div class="slide-page">
-        <!-- Change fix to use calc(vw + px) to fix this -->
-        <h2 class="slide-title" style="margin-top: -120px;">Publications</h2>
+        <div class="title-wrapper">
+          <h2 class="slide-title">PUBLICATIONS</h2>
+        </div>
         <div class="pub-flex-wrapper">
             <div class="pub-img-wrapper">
               <img class="pub-img" src="img/wip.png" alt="WIP">
@@ -169,7 +174,9 @@
     </div>
     <div class="slider slide4">
       <div class="slide-page">
-        <h2 class="slide-title">Mega Link Zone</h2>
+        <div class="title-wrapper">
+          <h2 class="slide-title">LINKS</h2>
+        </div>
         <div class="links-flex-wrapper">
           <div class="link-item">
             <a href="https://github.com/HenriMalahieude" target="_blank">

--- a/style.css
+++ b/style.css
@@ -31,7 +31,6 @@ body {
 .slider {
 	width: 100%;
 	height: 100%;
-	position: absolute;
 	top: 0;
 	left: 0;
 	opacity: 1;
@@ -50,6 +49,8 @@ body {
 	transition: -webkit-transform 1600ms, transform 1600ms;
 	-webkit-transform: scale(1);
 	transform: scale(1);
+	position: fixed !important;
+	overflow: auto;
 }
 
 /* Individual slide positions */
@@ -105,7 +106,8 @@ body {
 /* Slider pager */
 .slider-pagination {
 	/* Stick navbar to top */
-	position: sticky;
+	position: fixed !important;
+	top: 0;
 	display: flex;
 	justify-content: space-between;
 	align-items: center;
@@ -302,8 +304,19 @@ hr {
 
 /* Slide content styles */
 .slide-page {
-	margin: 50px 100px;
+	padding: 50px 100px !important;
 	max-height: 100%;
+}
+
+.title-wrapper {
+	margin-top: 100px;
+	display: flex;
+	min-width: 100%;
+	width: 100%;
+	max-width: 100%;
+	flex-basis: 100%;
+	justify-content: center;
+	align-items: center;
 }
 
 .slide-title {
@@ -311,6 +324,20 @@ hr {
 	text-shadow: #000 1px 5px 10px;
 	font-size: 50px !important;
 	margin: 0;
+}
+
+.web-link {
+	color: #0088cc;
+	padding: 2px 3px;
+	border: 1px solid #0088cc;
+	background-color: rgba(0, 0, 0, 0.5);
+	box-shadow: 10px 10px 10px rgba(0, 0, 0, .5);
+	text-decoration: none;
+	transition: all 150ms ease-in-out;
+}
+
+.web-link:hover {
+	border:  solid #3046c0 1px;
 }
 
 
@@ -467,23 +494,21 @@ hr {
 /****************************/
 
 /* General queries */
-@media only screen and (max-width: 900px) {
-	/* Note: the way titles are set up is sort of... trash */
-	/*       this is an easy fix for the time being.       */
+@media only screen and (max-width: 550px) {
 	.slide-title {
-		display: none;
+		font-size: 40px !important;
 	}
 }
 
 @media only screen and (max-width: 650px) {
 	.slide-page {
-		margin: 50px 25px;
+		padding: 50px 25px !important;
 	}
 }
 
 @media only screen and (max-width: 600px) {
 	body {
-		overflow-y: auto;
+		overflow-y: hidden !important;
 	}
 
 	.css-slider-wrapper {
@@ -530,6 +555,19 @@ hr {
 	}
 }
 
+@media only screen and (max-width: 450px) {
+	.home-flex-img-wrapper {
+		width: 65%;
+		margin-top: 10px;
+	}
+}
+
+@media only screen and (max-width: 375px) {
+	.home-flex-img-wrapper {
+		margin-top: 20px;
+	}
+}
+
 /* Projects slide */
 @media only screen and (max-width: 1345px) {
 	.projects-flex-item {
@@ -537,7 +575,7 @@ hr {
 	}
 }
 
-@media only screen and (max-width: 800px) {
+@media only screen and (max-width: 900px) {
 	.projects-flex-item {
 		margin: 20px 10px;
 		width: 45%;


### PR DESCRIPTION
Fixed a bunch of issues and added titles back to mobile view.

- Navbar now sticks to the top 
- Overflow should be fixed now
- Titles for each slide are back on mobile now
- Fixed resizing for ultrawide monitors
- Cleaned up useless styles

If anything looks incorrect or their are any other issues, let me know.